### PR TITLE
포켓 알림 종료일 추가

### DIFF
--- a/Projects/App/Pobi/Extension/PocketModel+.swift
+++ b/Projects/App/Pobi/Extension/PocketModel+.swift
@@ -21,7 +21,7 @@ extension PocketModel {
   }
   
   public func deletePushAlarm() {
-    LocalNotiCenter.shared.remove(id: id.uuidString, type: pushType)
+    LocalNotiCenter.shared.remove(id: id.uuidString, type: pushType, time: alarm.time)
   }
   
   public var pushType: TrigerType {
@@ -32,7 +32,7 @@ extension PocketModel {
         return .day(days: alarm.days)
       }
     } else {
-      return .date(alarm.date)
+      return .date(start: alarm.date, end: alarm.endDate)
     }
   }
 }

--- a/Projects/App/Pobi/Extension/PocketModel+.swift
+++ b/Projects/App/Pobi/Extension/PocketModel+.swift
@@ -24,7 +24,7 @@ extension PocketModel {
     LocalNotiCenter.shared.remove(id: id.uuidString, type: pushType, time: alarm.time)
   }
   
-  public var pushType: TrigerType {
+  public var pushType: RepeatType {
     if repeats {
       if alarm.isWeekRepeat {
         return .week(weeks: alarm.days)

--- a/Projects/App/Pobi/Models/PBFormatter.swift
+++ b/Projects/App/Pobi/Models/PBFormatter.swift
@@ -11,7 +11,23 @@ final class PBFormatter: Sendable, ObservableObject {
   private let weeks = [2,3,4,5,6,7,1] // 월요일 부터 시작
   let dateFormatter = DateFormatter()
   
-  func label(_ date: Date, format: String, locale: Locale? = nil) -> String {
+  func alarmLabel(_ date: Date, endDate: Date?) -> String {
+    var label = self.label(date, format: "yy년 M월 d일")
+    if let endDate {
+      let startDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: date)
+      let endDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: endDate)
+      if startDateComponents.year != endDateComponents.year {
+        label += " - " + self.label(endDate, format: "yy년 M월 d일")
+      } else if startDateComponents.month != endDateComponents.month {
+        label += " - " + self.label(endDate, format: "M월 d일")
+      } else if startDateComponents.day != endDateComponents.day {
+        label += " - " + self.label(endDate, format: "d일")
+      }
+    }
+    return label
+  }
+  
+  func label(_ date: Date, endDate: Date? = nil, format: String, locale: Locale? = nil) -> String {
     dateFormatter.dateFormat = format
     dateFormatter.locale = locale
     return dateFormatter.string(from: date)

--- a/Projects/App/Pobi/Scenes/CreatePocket/Features/CreatePocketFeature.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/Features/CreatePocketFeature.swift
@@ -79,7 +79,7 @@ struct CreatePocketFeature {
         }
       case .edit:
         guard let pocketModel = state.pocketModel else { return .none }
-        localNotiCenter.remove(id: pocketModel.id.uuidString, type: pocketModel.pushType)
+        localNotiCenter.remove(id: pocketModel.id.uuidString, type: pocketModel.pushType, time: pocketModel.alarm.time)
         pocketModel.paste(state.pocket)
         if state.pocket.onAlarm {
           let nickName = profileStorage.loadNickname() ?? "사용자"

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/DateSelectView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/DateSelectView.swift
@@ -7,9 +7,30 @@
 
 import SwiftUI
 
+import PBStorageInterface
 import PBDesignSystem
 
 struct DateSelectView: View {
+  private enum DateType {
+    case start
+    case end
+  }
+  
+  @State private var selectedDate: DateType = .start
+  @State private var startDate: Date
+  @State private var endDate: Date
+  @Binding private var pocket: Pocket
+  @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject private var formatter: PBFormatter
+  
+  init(
+    pocket: Binding<Pocket>
+  ) {
+    self.startDate = pocket.wrappedValue.alarm.date
+    self.endDate = pocket.wrappedValue.alarm.endDate
+    self._pocket = pocket
+  }
+  
   var body: some View {
     VStack {
       HStack(alignment: .bottom, spacing: 32) {
@@ -18,10 +39,13 @@ struct DateSelectView: View {
             .foregroundStyle(PBColors.navy._300.color)
             .font(PBFonts.label._2.font)
           
-          Text("25년 7월 23일")
-            .foregroundStyle(PBColors.navy._900.color)
+          Text(startDateLabel)
+            .foregroundStyle(
+              selectedDate == .start ? PBColors.yellow._500.color : PBColors.navy._900.color
+            )
             .font(PBFonts.subTitie._1.font)
         }
+        .onTapGesture { selectedDate = .start }
         PBShapes.arrow(lineWidht: 2.5,direction: .right)
           .frame(width: 18, height: 10)
           .foregroundStyle(PBColors.navy._100.color)
@@ -31,15 +55,21 @@ struct DateSelectView: View {
             .foregroundStyle(PBColors.navy._300.color)
             .font(PBFonts.label._2.font)
           
-          Text("25년 7월 23일")
-            .foregroundStyle(PBColors.navy._900.color)
+          Text(endDateLabel)
+            .foregroundStyle(
+              selectedDate == .end ? PBColors.yellow._500.color : PBColors.navy._900.color
+            )
             .font(PBFonts.subTitie._1.font)
         }
+        .onTapGesture { selectedDate = .end }
       }
       .padding(.top, 22)
       DatePicker(
         "",
-        selection: .constant(.now),
+        selection: Binding(
+          get: { selectedDate == .start ? startDate : endDate },
+          set: { setDate($0) }
+        ),
         displayedComponents: .date
       )
       .padding(.horizontal, 20)
@@ -49,7 +79,9 @@ struct DateSelectView: View {
       .environment(\.locale, Locale(identifier: Locale.preferredLanguages[0]))
       
       PBRoundButton(16) {
-
+        pocket.alarm.date = startDate
+        pocket.alarm.endDate = endDate
+        dismiss()
       } label: {
         Text("설정")
           .foregroundStyle(.white)
@@ -65,9 +97,36 @@ struct DateSelectView: View {
   }
 }
 
+private extension DateSelectView {
+  var startDateLabel: String {
+    formatter.label(startDate, format: "YY년 MM월 dd일")
+  }
+  
+  var endDateLabel: String {
+    formatter.label(endDate, format: "YY년 MM월 dd일")
+  }
+  
+  func setDate(_ date: Date) {
+    if selectedDate == .start {
+      if date > endDate {
+        endDate = date
+      }
+      startDate = date
+    } else {
+      if date < startDate {
+        startDate = date
+      }
+      endDate = date
+    }
+  }
+}
+
 #Preview {
+  @Previewable @State var pocket = Pocket()
+  
   Color.white
     .sheet(isPresented: .constant(true), content: {
-      DateSelectView()
+      DateSelectView(pocket: $pocket)
+        .environmentObject(PBFormatter())
     })
 }

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/DateSelectView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/DateSelectView.swift
@@ -1,0 +1,73 @@
+//
+//  DateSelectView.swift
+//  Pobi
+//
+//  Created by 이시원 on 7/30/25.
+//
+
+import SwiftUI
+
+import PBDesignSystem
+
+struct DateSelectView: View {
+  var body: some View {
+    VStack {
+      HStack(alignment: .bottom, spacing: 32) {
+        VStack(spacing: 6) {
+          Text("시작")
+            .foregroundStyle(PBColors.navy._300.color)
+            .font(PBFonts.label._2.font)
+          
+          Text("25년 7월 23일")
+            .foregroundStyle(PBColors.navy._900.color)
+            .font(PBFonts.subTitie._1.font)
+        }
+        PBShapes.arrow(lineWidht: 2.5,direction: .right)
+          .frame(width: 18, height: 10)
+          .foregroundStyle(PBColors.navy._100.color)
+          .padding(.bottom, 6)
+        VStack(spacing: 6) {
+          Text("종료")
+            .foregroundStyle(PBColors.navy._300.color)
+            .font(PBFonts.label._2.font)
+          
+          Text("25년 7월 23일")
+            .foregroundStyle(PBColors.navy._900.color)
+            .font(PBFonts.subTitie._1.font)
+        }
+      }
+      .padding(.top, 22)
+      DatePicker(
+        "",
+        selection: .constant(.now),
+        displayedComponents: .date
+      )
+      .padding(.horizontal, 20)
+      .labelsHidden()
+      .tint(PBColors.yellow._500.color)
+      .datePickerStyle(.graphical)
+      .environment(\.locale, Locale(identifier: Locale.preferredLanguages[0]))
+      
+      PBRoundButton(16) {
+
+      } label: {
+        Text("설정")
+          .foregroundStyle(.white)
+          .font(PBFonts.body._1.font)
+      }
+      .foregroundStyle(PBColors.navy._900.color)
+      .frame(height: 52)
+      .padding(.horizontal, 20)
+      .padding(.top, 10)
+    }
+    .presentationCornerRadius(30)
+    .presentationDetents([.height(550)])
+  }
+}
+
+#Preview {
+  Color.white
+    .sheet(isPresented: .constant(true), content: {
+      DateSelectView()
+    })
+}

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/RepeatsSelectView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/RepeatsSelectView.swift
@@ -152,7 +152,7 @@ struct RepeatsSelectView: View {
       }
       .disabled(isSettingButtonDisabled)
       .foregroundStyle(PBColors.navy._900.color)
-      .frame(height: 48)
+      .frame(height: 52)
     }
     .padding(.top, 24)
     .padding(.horizontal, 20)

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/RepeatsSelectView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/RepeatsSelectView.swift
@@ -1,5 +1,5 @@
 //
-//  DateSelectView.swift
+//  RepeatsSelectView.swift
 //  Pobi
 //
 //  Created by 이시원 on 3/10/25.
@@ -10,7 +10,7 @@ import SwiftUI
 import PBDesignSystem
 import PBStorageInterface
 
-struct DateSelectView: View {
+struct RepeatsSelectView: View {
   enum Weekday: Int, CaseIterable, CustomStringConvertible {
     case mon = 2
     case tues = 3
@@ -161,7 +161,7 @@ struct DateSelectView: View {
   }
 }
 
-extension DateSelectView {
+extension RepeatsSelectView {
   var isSettingButtonDisabled: Bool {
     if selectedTabIndex == 0, selectedWeekDays.isEmpty { return true }
     else if selectedTabIndex == 1, selectedDays.isEmpty { return true }
@@ -171,7 +171,7 @@ extension DateSelectView {
 
 #Preview {
   Color.white
-    .sheet(isPresented: .constant(true), content: { DateSelectView(alarm: .constant(.init(isWeekRepeat: true, days: [1,2,3,4,5,6,7], date: .now, time: .now)))
+    .sheet(isPresented: .constant(true), content: { RepeatsSelectView(alarm: .constant(.init(isWeekRepeat: true, days: [1,2,3,4,5,6,7], date: .now, time: .now)))
           
     })
 }

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
@@ -142,13 +142,7 @@ private extension SettingAlarmView {
   }
   
   var dateLabel: String {
-    let startDate = formatter.label(pocket.alarm.date, format: "yy년 M월 d일")
-    let endDate = formatter.label(pocket.alarm.endDate, format: "yy년 M월 d일")
-    if startDate == endDate {
-      return startDate
-    } else {
-      return "\(startDate) - \(endDate)"
-    }
+    formatter.alarmLabel(pocket.alarm.date, endDate: pocket.alarm.endDate)
   }
 }
 

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
@@ -11,9 +11,10 @@ import PBDesignSystem
 import PBStorageInterface
 
 struct SettingAlarmView: View {
-  @State private var isSelectedDate = false
   @State private var isSelectedTime = false
   @State private var isPresentedRepeatsSelectView = false
+  @State private var isPresentedDateSelectView = false
+
   @Binding private var pocket: Pocket
   @Binding private var isDidTapDownButton: Bool
   @FocusState private var isFocused: Bool
@@ -45,7 +46,7 @@ struct SettingAlarmView: View {
             isPresentedRepeatsSelectView.toggle()
           } else {
             withAnimation(.default.speed(1.5)) {
-              isSelectedDate.toggle()
+              isPresentedDateSelectView.toggle()
               isDidTapDownButton = false
               isSelectedTime = false
               isFocused = false
@@ -58,7 +59,7 @@ struct SettingAlarmView: View {
               .font(PBFonts.caption._1.font)
               .foregroundStyle(PBColors.navy._300.color)
               .lineLimit(1)
-              .frame(maxWidth: 150, alignment: .trailing)
+              .frame(maxWidth: 250, alignment: .trailing)
             PBImages.right.image
           }
           .frame(height: 34)
@@ -66,27 +67,6 @@ struct SettingAlarmView: View {
       }
       .padding(.horizontal, 20)
       .padding(.bottom, 8)
-      
-      VStack(spacing: 0) {
-        if isSelectedDate {
-          Divider()
-        }
-        DatePicker(
-          "",
-          selection: $pocket.alarm.date,
-          displayedComponents: .date
-        )
-        .frame(height: isSelectedDate ? nil : 0, alignment: .top)
-        .tint(PBColors.yellow._500.color)
-        .datePickerStyle(.graphical)
-        .environment(\.locale, Locale(identifier: Locale.preferredLanguages[0]))
-        if isSelectedDate {
-          Divider()
-        }
-      }
-      .padding(.horizontal, 20)
-      .disabled(!isSelectedDate)
-      .clipped()
       
       HStack {
         Text("시간")
@@ -98,7 +78,6 @@ struct SettingAlarmView: View {
             isSelectedTime.toggle()
             isDidTapDownButton = false
             isFocused = false
-            isSelectedDate = false
           }
         } label: {
           Text(timeLabel)
@@ -119,12 +98,15 @@ struct SettingAlarmView: View {
             .padding(.horizontal, 20)
         }
         
-        DatePicker(
-          "",
-          selection: $pocket.alarm.time,
-          displayedComponents: .hourAndMinute
-        )
-        .datePickerStyle(.wheel)
+        HStack {
+          DatePicker(
+            "",
+            selection: $pocket.alarm.time,
+            displayedComponents: .hourAndMinute
+          )
+          .labelsHidden()
+          .datePickerStyle(.wheel)
+        }
         .frame(height: isSelectedTime ? nil : 0, alignment: .top)
       }
       .disabled(!isSelectedTime)
@@ -133,15 +115,9 @@ struct SettingAlarmView: View {
     .padding(.vertical, 16)
     .background(.white)
     .clipShape(RoundedRectangle(cornerRadius: 20))
-    .onChange(of: pocket.repeats, { _, _ in
-      withAnimation {
-        isSelectedDate = false
-      }
-    })
     .onChange(of: isDidTapDownButton, { _, new in
       guard new else { return }
       withAnimation {
-        isSelectedDate = false
         isSelectedTime = false
       }
     })
@@ -149,6 +125,9 @@ struct SettingAlarmView: View {
       RepeatsSelectView(
         alarm: Binding(get: { pocket.alarm }, set: { pocket.alarm = $0 })
       )
+    }
+    .sheet(isPresented: $isPresentedDateSelectView) {
+      DateSelectView(pocket: $pocket)
     }
   }
 }
@@ -163,15 +142,22 @@ private extension SettingAlarmView {
   }
   
   var dateLabel: String {
-    formatter.label(pocket.alarm.date, format: "yyyy년 M월 d일")
+    let startDate = formatter.label(pocket.alarm.date, format: "yy년 M월 d일")
+    let endDate = formatter.label(pocket.alarm.endDate, format: "yy년 M월 d일")
+    if startDate == endDate {
+      return startDate
+    } else {
+      return "\(startDate) - \(endDate)"
+    }
   }
 }
 
 #Preview {
   @Previewable @FocusState var isFocused: Bool
+  @Previewable @State var pocket = Pocket()
   
   SettingAlarmView(
-    pocket: .constant(.init()),
+    pocket: $pocket,
     isFocused: _isFocused,
     isDidTapDownButton: .constant(false)
   )

--- a/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
+++ b/Projects/App/Pobi/Scenes/CreatePocket/View/SettingAlarmView.swift
@@ -13,7 +13,7 @@ import PBStorageInterface
 struct SettingAlarmView: View {
   @State private var isSelectedDate = false
   @State private var isSelectedTime = false
-  @State private var isPresentedDataSelectView = false
+  @State private var isPresentedRepeatsSelectView = false
   @Binding private var pocket: Pocket
   @Binding private var isDidTapDownButton: Bool
   @FocusState private var isFocused: Bool
@@ -42,7 +42,7 @@ struct SettingAlarmView: View {
         Spacer()
         Button {
           if pocket.repeats {
-            isPresentedDataSelectView.toggle()
+            isPresentedRepeatsSelectView.toggle()
           } else {
             withAnimation(.default.speed(1.5)) {
               isSelectedDate.toggle()
@@ -145,8 +145,8 @@ struct SettingAlarmView: View {
         isSelectedTime = false
       }
     })
-    .sheet(isPresented: $isPresentedDataSelectView) {
-      DateSelectView(
+    .sheet(isPresented: $isPresentedRepeatsSelectView) {
+      RepeatsSelectView(
         alarm: Binding(get: { pocket.alarm }, set: { pocket.alarm = $0 })
       )
     }

--- a/Projects/App/Pobi/Scenes/Home/Views/PocketCell.swift
+++ b/Projects/App/Pobi/Scenes/Home/Views/PocketCell.swift
@@ -98,7 +98,7 @@ private extension PocketCell {
     if pocket.repeats {
       return formatter.label(isWeekDay: pocket.alarm.isWeekRepeat, days: pocket.alarm.days)
     }
-    return formatter.label(pocket.alarm.date, format: "M월 d일")
+    return formatter.alarmLabel(pocket.alarm.date, endDate: pocket.alarm.endDate)
   }
 }
 
@@ -113,7 +113,25 @@ private extension PocketCell {
 }
 
 #Preview("date") {
-  PocketCell(PocketModel(id: .init(), title: "테스트", onAlarm: true, alarm: .init(isWeekRepeat: true, days: [1,2], date: .now, time: .now)))
+  PocketCell(PocketModel(id: .init(), title: "테스트", onAlarm: true, alarm: .init(isWeekRepeat: true, days: [1,2], date: .now, endDate: .now, time: .now)))
+    .environmentObject(PBFormatter())
+}
+
+#Preview("date-endDate") {
+  PocketCell(
+    PocketModel(
+      id: .init(),
+      title: "테스트",
+      onAlarm: true,
+      alarm: .init(
+        isWeekRepeat: true,
+        days: [1,2],
+        date: Calendar.current.date(from: DateComponents(year: 2025, month: 3, day: 20))!,
+        endDate: .now,
+        time: .now
+      )
+    )
+  )
     .environmentObject(PBFormatter())
 }
 

--- a/Projects/App/Pobi/Scenes/PocketDetail/PocketDetailView.swift
+++ b/Projects/App/Pobi/Scenes/PocketDetail/PocketDetailView.swift
@@ -103,7 +103,10 @@ private extension PocketDetailView {
             Text("\(time)")
           })
       }
-      let date = formatter.label(pocket.alarm.date, format: "M월 d일")
+      var date = formatter.alarmLabel(
+        pocket.alarm.date,
+        endDate: pocket.alarm.endDate
+      )
       return AnyView(
         HStack(spacing: 0) {
           Text("\(date)")
@@ -121,7 +124,32 @@ private extension PocketDetailView {
       PocketModel(
         title: "테스트",
         onAlarm: true,
-        alarm: PocketAlarmModel(isWeekRepeat: true, days: [1,2], date: .now, time: .now)
+        alarm: PocketAlarmModel(
+          isWeekRepeat: true,
+          days: [1,2],
+          date: Calendar.current.date(from: DateComponents(year: 2025, month: 12, day: 20))!,
+          endDate:  Calendar.current.date(from: DateComponents(year: 2025, month: 12, day: 29))!,
+          time: .now
+        )
+      )
+    )
+    .environmentObject(PBFormatter())
+  }
+}
+
+#Preview {
+  NavigationStack {
+    PocketDetailView(
+      PocketModel(
+        title: "테스트",
+        onAlarm: true,
+        alarm: PocketAlarmModel(
+          isWeekRepeat: true,
+          days: [1,2],
+          date: .now,
+          endDate: .now,
+          time: .now
+        )
       )
     )
     .environmentObject(PBFormatter())

--- a/Projects/LocalNotiService/LocalNotiInterface/LocalNotiInterface.swift
+++ b/Projects/LocalNotiService/LocalNotiInterface/LocalNotiInterface.swift
@@ -11,7 +11,7 @@ import UserNotifications
 public protocol Notifiable: Sendable {
   func isOnAlarm() async -> Bool
   func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
-  func register(title: String, body: String, id: String, trigerType: TrigerType, time: Date)
-  func remove(id: String, type: TrigerType, time: Date)
+  func register(title: String, body: String, id: String, trigerType: RepeatType, time: Date)
+  func remove(id: String, type: RepeatType, time: Date)
   func removeAll()
 }

--- a/Projects/LocalNotiService/LocalNotiInterface/LocalNotiInterface.swift
+++ b/Projects/LocalNotiService/LocalNotiInterface/LocalNotiInterface.swift
@@ -12,6 +12,6 @@ public protocol Notifiable: Sendable {
   func isOnAlarm() async -> Bool
   func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
   func register(title: String, body: String, id: String, trigerType: TrigerType, time: Date)
-  func remove(id: String, type: TrigerType)
+  func remove(id: String, type: TrigerType, time: Date)
   func removeAll()
 }

--- a/Projects/LocalNotiService/LocalNotiInterface/RepeatType.swift
+++ b/Projects/LocalNotiService/LocalNotiInterface/RepeatType.swift
@@ -1,5 +1,5 @@
 //
-//  TrigerType.swift
+//  RepeatType.swift
 //  LocalNotiService
 //
 //  Created by 이시원 on 3/24/25.
@@ -7,7 +7,7 @@
 
 import UserNotifications
 
-@frozen public enum TrigerType: Equatable {
+@frozen public enum RepeatType: Equatable {
   case day(days: [Int])
   case week(weeks: [Int])
   case date(start: Date, end: Date?)

--- a/Projects/LocalNotiService/LocalNotiInterface/TrigerType.swift
+++ b/Projects/LocalNotiService/LocalNotiInterface/TrigerType.swift
@@ -7,75 +7,8 @@
 
 import UserNotifications
 
-public enum TrigerType: Equatable {
+@frozen public enum TrigerType: Equatable {
   case day(days: [Int])
   case week(weeks: [Int])
-  case date(Date)
-  
-  public func requsetIds(id: String) -> [String] {
-    switch self {
-    case let .day(days):
-      return days.map { id + "-\($0)" }
-    case let .week(weeks):
-      return weeks.map { id + "-\($0)" }
-    case let .date(date):
-      return [id + "-\(date.description)"]
-    }
-  }
-  
-  public func makeRequsts(time: Date, id: String, content: UNMutableNotificationContent) -> [UNNotificationRequest] {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "HH-m"
-    let splitedTime = dateFormatter
-      .string(from: time)
-      .split(separator: "-")
-      .compactMap({ Int($0) })
-    let hour = splitedTime[0]
-    let minute = splitedTime[1]
-    var dateComponents = DateComponents()
-    dateComponents.hour = hour
-    dateComponents.minute = minute
-    
-    switch self {
-    case let .day(days): // 매달 특정 일에 반복
-      return Array(zip(days, self.requsetIds(id: id)))
-        .map { (day: Int, id: String) in
-          dateComponents.day = day
-          let triger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-          return UNNotificationRequest(
-            identifier: id,
-            content: content,
-            trigger: triger
-          )
-        }
-    case let .week(weeks): // 매주 특정 요일마다 반복
-      return Array(zip(weeks, self.requsetIds(id: id)))
-        .map { (week: Int, id: String) in
-          dateComponents.weekday = week
-          let triger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-          return UNNotificationRequest(
-            identifier: id,
-            content: content,
-            trigger: triger
-          )
-        }
-    case let .date(date): // 특정 날짜 하루
-      dateFormatter.dateFormat = "yyyy-M-d"
-      let splitedDate = dateFormatter
-        .string(from: date)
-        .components(separatedBy: "-")
-        .compactMap { Int($0) }
-      dateComponents.year = splitedDate[0]
-      dateComponents.month = splitedDate[1]
-      dateComponents.day = splitedDate[2]
-      let triger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
-      return [
-        UNNotificationRequest(
-          identifier: self.requsetIds(id: id)[0],
-          content: content,
-          trigger: triger
-        )
-      ]
-    }
-  }
+  case date(start: Date, end: Date?)
 }

--- a/Projects/LocalNotiService/LocalNotiService.xcodeproj/project.pbxproj
+++ b/Projects/LocalNotiService/LocalNotiService.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9B3B90052E1E3431006CB25A /* LocalNotiInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B3B8FC72E1E28CA006CB25A /* LocalNotiInterface.framework */; };
 		9B4DC8992D8FE28B00978C6E /* LocalNotiService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B4DC8762D8FA9C300978C6E /* LocalNotiService.framework */; };
 		9B4DC89A2D8FE28B00978C6E /* LocalNotiService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9B4DC8762D8FA9C300978C6E /* LocalNotiService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9B6C66012E3CAF91000C6964 /* LocalNotiService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B4DC8762D8FA9C300978C6E /* LocalNotiService.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +39,13 @@
 			remoteInfo = LocalNotiInterface;
 		};
 		9B4DC89B2D8FE28B00978C6E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B4DC86D2D8FA9C300978C6E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B4DC8752D8FA9C300978C6E;
+			remoteInfo = LocalNotiService;
+		};
+		9B6C66022E3CAF91000C6964 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9B4DC86D2D8FA9C300978C6E /* Project object */;
 			proxyType = 1;
@@ -75,6 +83,7 @@
 		9B3B8FFE2E1E3429006CB25A /* libLocalNotiTesting.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLocalNotiTesting.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B4DC8762D8FA9C300978C6E /* LocalNotiService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LocalNotiService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B4DC88A2D8FE27300978C6E /* LocalNotiDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LocalNotiDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B6C65FD2E3CAF91000C6964 /* LocalNotiServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LocalNotiServiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -109,6 +118,11 @@
 		9B4DC88B2D8FE27300978C6E /* LocalNotiDemo */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = LocalNotiDemo;
+			sourceTree = "<group>";
+		};
+		9B6C65FE2E3CAF91000C6964 /* LocalNotiServiceTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = LocalNotiServiceTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -146,6 +160,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B6C65FA2E3CAF91000C6964 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B6C66012E3CAF91000C6964 /* LocalNotiService.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -156,6 +178,7 @@
 				9B4DC88B2D8FE27300978C6E /* LocalNotiDemo */,
 				9B3B8FC82E1E28CA006CB25A /* LocalNotiInterface */,
 				9B3B8FFF2E1E3429006CB25A /* LocalNotiTesting */,
+				9B6C65FE2E3CAF91000C6964 /* LocalNotiServiceTests */,
 				9B4DC8982D8FE28B00978C6E /* Frameworks */,
 				9B4DC8772D8FA9C300978C6E /* Products */,
 			);
@@ -168,6 +191,7 @@
 				9B4DC88A2D8FE27300978C6E /* LocalNotiDemo.app */,
 				9B3B8FC72E1E28CA006CB25A /* LocalNotiInterface.framework */,
 				9B3B8FFE2E1E3429006CB25A /* libLocalNotiTesting.a */,
+				9B6C65FD2E3CAF91000C6964 /* LocalNotiServiceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -294,6 +318,29 @@
 			productReference = 9B4DC88A2D8FE27300978C6E /* LocalNotiDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		9B6C65FC2E3CAF91000C6964 /* LocalNotiServiceTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9B6C66062E3CAF91000C6964 /* Build configuration list for PBXNativeTarget "LocalNotiServiceTests" */;
+			buildPhases = (
+				9B6C65F92E3CAF91000C6964 /* Sources */,
+				9B6C65FA2E3CAF91000C6964 /* Frameworks */,
+				9B6C65FB2E3CAF91000C6964 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9B6C66032E3CAF91000C6964 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				9B6C65FE2E3CAF91000C6964 /* LocalNotiServiceTests */,
+			);
+			name = LocalNotiServiceTests;
+			packageProductDependencies = (
+			);
+			productName = LocalNotiServiceTests;
+			productReference = 9B6C65FD2E3CAF91000C6964 /* LocalNotiServiceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -316,6 +363,9 @@
 					9B4DC8892D8FE27300978C6E = {
 						CreatedOnToolsVersion = 16.2;
 					};
+					9B6C65FC2E3CAF91000C6964 = {
+						CreatedOnToolsVersion = 16.3;
+					};
 				};
 			};
 			buildConfigurationList = 9B4DC8702D8FA9C300978C6E /* Build configuration list for PBXProject "LocalNotiService" */;
@@ -336,6 +386,7 @@
 				9B4DC8892D8FE27300978C6E /* LocalNotiDemo */,
 				9B3B8FC62E1E28CA006CB25A /* LocalNotiInterface */,
 				9B3B8FFD2E1E3429006CB25A /* LocalNotiTesting */,
+				9B6C65FC2E3CAF91000C6964 /* LocalNotiServiceTests */,
 			);
 		};
 /* End PBXProject section */
@@ -356,6 +407,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		9B4DC8882D8FE27300978C6E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9B6C65FB2E3CAF91000C6964 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -393,6 +451,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B6C65F92E3CAF91000C6964 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -415,6 +480,11 @@
 			isa = PBXTargetDependency;
 			target = 9B4DC8752D8FA9C300978C6E /* LocalNotiService */;
 			targetProxy = 9B4DC89B2D8FE28B00978C6E /* PBXContainerItemProxy */;
+		};
+		9B6C66032E3CAF91000C6964 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9B4DC8752D8FA9C300978C6E /* LocalNotiService */;
+			targetProxy = 9B6C66022E3CAF91000C6964 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -768,6 +838,40 @@
 			};
 			name = Release;
 		};
+		9B6C66042E3CAF91000C6964 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S44QFR96WL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.siwon.LocalNotiServiceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9B6C66052E3CAF91000C6964 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S44QFR96WL;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.siwon.LocalNotiServiceTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -812,6 +916,15 @@
 			buildConfigurations = (
 				9B4DC8962D8FE27400978C6E /* Debug */,
 				9B4DC8972D8FE27400978C6E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9B6C66062E3CAF91000C6964 /* Build configuration list for PBXNativeTarget "LocalNotiServiceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9B6C66042E3CAF91000C6964 /* Debug */,
+				9B6C66052E3CAF91000C6964 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Projects/LocalNotiService/LocalNotiService/Sources/DateComponentsMaker.swift
+++ b/Projects/LocalNotiService/LocalNotiService/Sources/DateComponentsMaker.swift
@@ -8,7 +8,7 @@
 import LocalNotiInterface
 
 struct DateComponentsMaker {
-  func make(type: TrigerType, time: Date) -> [DateComponents] {
+  func make(type: RepeatType, time: Date) -> [DateComponents] {
     let timeComponents = Calendar.current.dateComponents([.hour, .minute], from: time)
     switch type {
     case let .day(days):

--- a/Projects/LocalNotiService/LocalNotiService/Sources/DateComponentsMaker.swift
+++ b/Projects/LocalNotiService/LocalNotiService/Sources/DateComponentsMaker.swift
@@ -1,0 +1,64 @@
+//
+//  DateComponentsMaker.swift
+//  LocalNotiService
+//
+//  Created by 이시원 on 8/1/25.
+//
+
+import LocalNotiInterface
+
+struct DateComponentsMaker {
+  func make(type: TrigerType, time: Date) -> [DateComponents] {
+    let timeComponents = Calendar.current.dateComponents([.hour, .minute], from: time)
+    switch type {
+    case let .day(days):
+      return days.map { day in
+        var newComponents = timeComponents
+        newComponents.day = day
+        return newComponents
+      }
+    case let .week(weeks):
+      return weeks.map { week in
+        var newComponents = timeComponents
+        newComponents.weekOfYear = week
+        return newComponents
+      }
+    case let .date(start, end):
+      var startDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: start)
+      var startDate = start
+      startDateComponents.hour = timeComponents.hour
+      startDateComponents.minute = timeComponents.minute
+      var dateComponents: [DateComponents] = [startDateComponents]
+      guard let end else { return dateComponents }
+      let endDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: end)
+      while startDateComponents < endDateComponents {
+        startDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+        startDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: startDate)
+        startDateComponents.hour = timeComponents.hour
+        startDateComponents.minute = timeComponents.minute
+        dateComponents.append(startDateComponents)
+      }
+      return dateComponents
+    }
+  }
+}
+
+private extension DateComponents {
+  func date(using calendar: Calendar = .current) -> Date? {
+    return calendar.date(from: self)
+  }
+  
+  static func < (lhs: DateComponents, rhs: DateComponents) -> Bool {
+    guard let lDate = lhs.date(), let rDate = rhs.date() else {
+      fatalError("비교하려는 DateComponents 중 Date로 변환할 수 없는 값이 있습니다.")
+    }
+    return lDate < rDate
+  }
+  
+  static func == (lhs: DateComponents, rhs: DateComponents) -> Bool {
+    guard let lDate = lhs.date(), let rDate = rhs.date() else {
+      return false
+    }
+    return lDate == rDate
+  }
+}

--- a/Projects/LocalNotiService/LocalNotiService/Sources/LocalNotiCenter.swift
+++ b/Projects/LocalNotiService/LocalNotiService/Sources/LocalNotiCenter.swift
@@ -39,7 +39,7 @@ public final class LocalNotiCenter: Notifiable {
     title: String,
     body: String,
     id: String,
-    trigerType: TrigerType,
+    trigerType: RepeatType,
     time: Date
   ) {
     let content = UNMutableNotificationContent()
@@ -62,7 +62,7 @@ public final class LocalNotiCenter: Notifiable {
     }
   }
   
-  public func remove(id: String, type: TrigerType, time: Date) {
+  public func remove(id: String, type: RepeatType, time: Date) {
     let ids = dateComponentsMaker.make(type: type, time: time).map { dateComponents in  id+"-\(dateComponents.description)" }
     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
   }

--- a/Projects/LocalNotiService/LocalNotiService/Sources/LocalNotiCenter.swift
+++ b/Projects/LocalNotiService/LocalNotiService/Sources/LocalNotiCenter.swift
@@ -11,7 +11,7 @@ import LocalNotiInterface
 
 public final class LocalNotiCenter: Notifiable {
   public static let shared = LocalNotiCenter()
-  
+  private let dateComponentsMaker: DateComponentsMaker = DateComponentsMaker()
   public init() {}
   
   public func isOnAlarm() async -> Bool {
@@ -47,13 +47,24 @@ public final class LocalNotiCenter: Notifiable {
     content.body = body
     content.sound = .default
     content.userInfo = ["id": id]
-    trigerType.makeRequsts(time: time, id: id, content: content).forEach {
-      UNUserNotificationCenter.current().add($0)
+    dateComponentsMaker.make(type: trigerType, time: time).forEach { dateComponents in
+      let isRepeat: Bool
+      switch trigerType {
+      case .day, .week:
+        isRepeat = true
+      case .date:
+        isRepeat = false
+      }
+      let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: isRepeat)
+      UNUserNotificationCenter.current().add(
+        UNNotificationRequest(identifier: id+"-\(dateComponents.description)", content: content, trigger: trigger)
+      )
     }
   }
   
-  public func remove(id: String, type: TrigerType) {
-    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: type.requsetIds(id: id))
+  public func remove(id: String, type: TrigerType, time: Date) {
+    let ids = dateComponentsMaker.make(type: type, time: time).map { dateComponents in  id+"-\(dateComponents.description)" }
+    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
   }
   
   public func removeAll() {

--- a/Projects/LocalNotiService/LocalNotiServiceTests/DateComponentsMakerTests.swift
+++ b/Projects/LocalNotiService/LocalNotiServiceTests/DateComponentsMakerTests.swift
@@ -1,0 +1,64 @@
+//
+//  DateComponentsMakerTests.swift
+//  LocalNotiServiceTests
+//
+//  Created by 이시원 on 8/1/25.
+//
+
+import XCTest
+@testable import LocalNotiService
+
+final class DateComponentsMakerTests: XCTestCase {
+  var sut: DateComponentsMaker!
+  override func setUpWithError() throws {
+    sut = DateComponentsMaker()
+  }
+  
+  override func tearDownWithError() throws {
+    sut = nil
+  }
+  
+  func test_make를_호출해_DateComponents_배열을_생성할_때_start_8월31일_end_9월2일인_경우_8월31일_9월1일2일_DateComponents가_생성된다() {
+    // Arrange
+    let startDate = Calendar.current.date(from: DateComponents(year:2025, month: 8, day: 31, hour: 9, minute: 9))!
+    let endDate: Date? = Calendar.current.date(from: DateComponents(year:2025, month: 9, day: 2, hour: 11, minute: 11))
+    let timeDate = Calendar.current.date(from: DateComponents(hour: 10, minute: 10))!
+    // Act
+    let output = sut.make(type: .date(start: startDate, end: endDate), time: timeDate)
+    // Assert
+    let result: [DateComponents] = [
+      DateComponents(year:2025, month: 8, day: 31, hour: 10, minute: 10),
+      DateComponents(year:2025, month: 9, day: 1, hour: 10, minute: 10),
+      DateComponents(year:2025, month: 9, day: 2, hour: 10, minute: 10)
+    ]
+    XCTAssertEqual(result, output)
+  }
+  
+  func test_make를_호출해_DateComponents_배열을_생성할_때_start_8월31일_end_nil_경우_8월31일_DateComponents가_생성된다() {
+    // Arrange
+    let startDate = Calendar.current.date(from: DateComponents(year:2025, month: 8, day: 31, hour: 9, minute: 9))!
+    let endDate: Date? = nil
+    let timeDate = Calendar.current.date(from: DateComponents(hour: 10, minute: 10))!
+    // Act
+    let output = sut.make(type: .date(start: startDate, end: endDate), time: timeDate)
+    // Assert
+    let result: [DateComponents] = [
+      DateComponents(year:2025, month: 8, day: 31, hour: 10, minute: 10)
+    ]
+    XCTAssertEqual(result, output)
+  }
+  
+  func test_make를_호출해_DateComponents_배열을_생성할_때_start_8월31일_end_8월31일로_동일할_경우_8월31일_DateComponents가_생성된다() {
+    // Arrange
+    let startDate = Calendar.current.date(from: DateComponents(year:2025, month: 8, day: 31, hour: 9, minute: 9))!
+    let endDate: Date? = Calendar.current.date(from: DateComponents(year:2025, month: 8, day: 31, hour: 11, minute: 11))!
+    let timeDate = Calendar.current.date(from: DateComponents(hour: 10, minute: 10))!
+    // Act
+    let output = sut.make(type: .date(start: startDate, end: endDate), time: timeDate)
+    // Assert
+    let result: [DateComponents] = [
+      DateComponents(year:2025, month: 8, day: 31, hour: 10, minute: 10)
+    ]
+    XCTAssertEqual(result, output)
+  }
+}

--- a/Projects/LocalNotiService/LocalNotiTesting/MockLocalNotiCenter.swift
+++ b/Projects/LocalNotiService/LocalNotiTesting/MockLocalNotiCenter.swift
@@ -25,8 +25,8 @@ public final class MockLocalNotiCenter: Notifiable, @unchecked Sendable {
   
   public struct InputValue {
     public var requestAuthorization: UNAuthorizationOptions?
-    public var register: (title: String, body: String, id: String, trigerType: TrigerType, time: Date)?
-    public var remove: (id: String, type: LocalNotiInterface.TrigerType)?
+    public var register: (title: String, body: String, id: String, trigerType: RepeatType, time: Date)?
+    public var remove: (id: String, type: LocalNotiInterface.RepeatType)?
   }
   
   public var callCount: CallCount = .init()
@@ -46,12 +46,12 @@ public final class MockLocalNotiCenter: Notifiable, @unchecked Sendable {
     return returnValue.requestAuthorization
   }
   
-  public func register(title: String, body: String, id: String, trigerType: TrigerType, time: Date) {
+  public func register(title: String, body: String, id: String, trigerType: RepeatType, time: Date) {
     callCount.register += 1
     inputValue.register = (title, body, id, trigerType, time)
   }
   
-  public func remove(id: String, type: LocalNotiInterface.TrigerType) {
+  public func remove(id: String, type: LocalNotiInterface.RepeatType) {
     callCount.remove += 1
     inputValue.remove = (id, type)
   }

--- a/Projects/PBCalender/PBCalendar/Sources/PBCalenderManager.swift
+++ b/Projects/PBCalender/PBCalendar/Sources/PBCalenderManager.swift
@@ -65,7 +65,13 @@ public final class PBCalendarManager: Sendable, ObservableObject {
               }
             }
           } else {
-            if calendar.date(pocket.alarm.date, matchesComponents: itemDateComponents) {
+            if let endDate = pocket.alarm.endDate {
+              if (date! >= pocket.alarm.date && date! <= endDate) ||
+                  calendar.date(pocket.alarm.date, matchesComponents: itemDateComponents) ||
+                  calendar.date(endDate, matchesComponents: itemDateComponents) {
+                targetPockets.append(pocket)
+              }
+            } else if calendar.date(pocket.alarm.date, matchesComponents: itemDateComponents) {
               targetPockets.append(pocket)
             }
           }

--- a/Projects/PBCalender/PBCalendarTests/PBCalendarTests.swift
+++ b/Projects/PBCalender/PBCalendarTests/PBCalendarTests.swift
@@ -83,6 +83,66 @@ final class PBCalendarTests: XCTestCase {
     XCTAssertEqual([["10, 10일 하루"]], output)
   }
   
+  func test_days_호출_시_date와_endDate가_10일로_동일할_경우_10일에_표시() {
+    // Arrange
+    let date = Calendar.current.date(from: DateComponents(year: 2025, month: 3))! // 2025년 3월
+    let pockets: [PocketModel] = [
+      PocketModel(
+        title: "10일 하루",
+        repeats: false,
+        alarm: PocketAlarmModel(
+          isWeekRepeat: false,
+          days: [],
+          date: Calendar.current.date(from: DateComponents(year: 2025, month: 3, day: 10, hour: 3, minute: 3))!,
+          endDate: Calendar.current.date(from: DateComponents(year: 2025, month: 3, day: 10, hour: 11, minute: 11))!,
+          time: .now
+        )
+      )
+    ]
+    // Act
+    let output = sut.days(in: date, with: pockets)
+      .filter { item in
+        !item.pockets.isEmpty
+      }
+      .map { item in
+        item.pockets.map {
+          "\(item.dateComponents.day!), \($0.title)"
+        }
+      }
+    // Assert
+    XCTAssertEqual([["10, 10일 하루"]], output)
+  }
+  
+  func test_days_호출_시_date_3월30일_endDate_4월2일인_경우_30일_부터_4일까지_표시() {
+    // Arrange
+    let date = Calendar.current.date(from: DateComponents(year: 2025, month: 3))! // 2025년 3월
+    let pockets: [PocketModel] = [
+      PocketModel(
+        title: "3월 30일 ~ 4월 2일",
+        repeats: false,
+        alarm: PocketAlarmModel(
+          isWeekRepeat: false,
+          days: [],
+          date: Calendar.current.date(from: DateComponents(year: 2025, month: 3, day: 30, hour: 3, minute: 3))!,
+          endDate: Calendar.current.date(from: DateComponents(year: 2025, month: 4, day: 2, hour: 11, minute: 11))!,
+          time: .now
+        )
+      )
+    ]
+    // Act
+    let output = sut.days(in: date, with: pockets)
+      .filter { item in
+        !item.pockets.isEmpty
+      }
+      .map { item in
+        item.pockets.map {
+          "\(item.dateComponents.day!), \($0.title)"
+        }
+      }
+    // Assert
+    XCTAssertEqual([["30, 3월 30일 ~ 4월 2일"], ["31, 3월 30일 ~ 4월 2일"], ["1, 3월 30일 ~ 4월 2일"], ["2, 3월 30일 ~ 4월 2일"]], output)
+  }
+  
   func test_days_호출_시_일요일_반복_포켓이_등록되어_있을_경우_매주_일요일에_표시() {
     // Arrange
     let date = Calendar.current.date(from: DateComponents(year: 2025, month: 3))! // 2025년 3월

--- a/Projects/PBStorage/PBStorageInterface/Models/PocketAlarmModel.swift
+++ b/Projects/PBStorage/PBStorageInterface/Models/PocketAlarmModel.swift
@@ -12,17 +12,31 @@ public final class PocketAlarmModel {
   public var isWeekRepeat: Bool
   public var days: [Int]
   public var date: Date
+  public var endDate: Date? = nil
   public var time: Date
   
-  public init(isWeekRepeat: Bool, days: [Int], date: Date, time: Date) {
+  public init(
+    isWeekRepeat: Bool,
+    days: [Int],
+    date: Date,
+    endDate: Date? = nil,
+    time: Date
+  ) {
     self.isWeekRepeat = isWeekRepeat
     self.days = days
     self.date = date
+    self.endDate = endDate
     self.time = time
   }
   
   public convenience init(_ alarm: Alarm) {
-    self.init(isWeekRepeat: alarm.isWeekRepeat, days: alarm.days, date: alarm.date, time: alarm.time)
+    self.init(
+      isWeekRepeat: alarm.isWeekRepeat,
+      days: alarm.days,
+      date: alarm.date,
+      endDate: alarm.endDate,
+      time: alarm.time
+    )
   }
   
   public func copy() -> PocketAlarmModel {
@@ -30,18 +44,26 @@ public final class PocketAlarmModel {
       isWeekRepeat: self.isWeekRepeat,
       days: self.days,
       date: self.date,
+      endDate: self.endDate,
       time: self.time
     )
   }
   
   public func temporary() -> Alarm {
-    return Alarm(isWeekRepeat: self.isWeekRepeat, days: self.days, date: self.date, time: self.time)
+    return Alarm(
+      isWeekRepeat: self.isWeekRepeat,
+      days: self.days,
+      date: self.date,
+      endDate: self.endDate,
+      time: self.time
+    )
   }
   
   public func paste(_ alarm: Alarm) {
     self.isWeekRepeat = alarm.isWeekRepeat
     self.days = alarm.days
     self.date = alarm.date
+    self.endDate = alarm.endDate
     self.time = alarm.time
   }
 }
@@ -50,17 +72,20 @@ public struct Alarm: Equatable {
   public var isWeekRepeat: Bool
   public var days: [Int]
   public var date: Date
+  public var endDate: Date
   public var time: Date
   
   public init(
     isWeekRepeat: Bool = true,
     days: [Int] = [1,2,3,4,5,6,7],
     date: Date = .now,
+    endDate: Date? = nil,
     time: Date = .now
   ) {
     self.isWeekRepeat = isWeekRepeat
     self.days = days
     self.date = date
+    self.endDate = endDate ?? date
     self.time = time
   }
 }


### PR DESCRIPTION
## 배경
포켓 알림 설정 시 기존 반복(요일 별, 매월) 알림 설정이 아닌 경우 하루 알림만 설정할 수 있는 불편함을 개선하기 위해 `알림 종료일`을 설정할 수 있도록 기능 확장

## 작업 내용
- Alarm Model endDate 속성 추가
- endDate 추가에 따른 LocalNotiService(알림), PBCalendar(캘린더) 기능 확장 및 테스트 코드 작성
- endDate 추가에 따른 UI 변경

## 성과
종료일 설정 시 시작일 부터 종료일까지 매일 푸쉬 알림을 받을 수 있도록 사용성 개선(ex. 25년 8월 1일 - 25년 8월 4일)

추가로, 알림 등록을 위해 `DateComponents`를 생성하는 로직이 포함된 객체가 `UserNotifications` Framework와 의존성으로 인해 테스트가 어려운 구조를 개선하기 위해 해당 코드를 `DateComponentsMaker`로직 분리하여 [테스트 코드](https://github.com/POBI-Team/POBI/blob/9aa34b384e1b2252e61aaf994a55fcce37b8ac95/Projects/LocalNotiService/LocalNotiServiceTests/DateComponentsMakerTests.swift) 작성